### PR TITLE
Migrated to Express 4

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,33 +1,31 @@
 var express = require('express'),
+    favicon = require('serve-favicon'),
+    static = require('serve-static'),
+    cookieParser = require('cookie-parser'),
+    bodyParser = require('body-parser'),
+    methodOverride = require('method-override'),
+    errorHandler = require('errorhandler'),
+    routes = require('./routes/GUI.js'),
     path = require('path'),
-    http = require('http'),
     nconf = require('nconf');
 
-//NConf Configuration
 nconf.env().file({ file: 'settings.json' });
 
-//Express Configuration
 var app = express();
 
-app.configure(function(){
-    app.set('port', process.env.PORT || 3000);
-    app.set('views', __dirname + '/html/src');
-    app.set('view engine', 'jade');
-    app.use(express.favicon());
-    //app.use(express.logger('dev'));
-    app.use(express.cookieParser());
-    app.use(express.urlencoded());
-    app.use(express.json());
-    app.use(express.methodOverride());
-    app.use(app.router);
-    app.use(express.static(path.join(__dirname, 'html/includes')));
-    app.engine('html', require('ejs').renderFile);
-});
+app.set('port', process.env.PORT || 3000);
+app.set('views', path.join(__dirname, 'html/src'));
+app.set('view engine', 'jade');
+app.use(favicon(path.join(__dirname, 'favicon.ico')));
+app.use(cookieParser());
+app.use(bodyParser.urlencoded({ extended: true }));
+app.use(bodyParser.json());
+app.use(methodOverride());
+app.use(static(path.join(__dirname, 'html/includes')));
 
-app.configure('development', function(){
-    app.use(express.errorHandler());
-});
+routes(app);
 
-require('./routes/GUI.js')(app);
+if (app.settings.env == 'development')
+    app.use(errorHandler());
 
 module.exports = app;

--- a/package.json
+++ b/package.json
@@ -48,21 +48,26 @@
     "delete-firebase": "node ./bin/delete_firebase.js https://bikesafetytwo.firebaseio.com HjQfDNcylTuOQ1X2GWxcO0QncISe0YXPKl7TcOjG"
   },
   "dependencies": {
+    "body-parser": "^1.15.0",
     "bower": "^1.3.12",
+    "cookie-parser": "^1.4.1",
     "csv": "^0.4.5",
-    "ejs": "~2.2.4",
-    "express": "~3.19.2",
-    "firebase": "~2.2.0",
+    "errorhandler": "^1.4.3",
+    "express": "~4.13.4",
+    "firebase": "~2.4.2",
     "highland": "^2.5.1",
-    "jade": "~1.9.2",
-    "lodash": "^3.8.0",
-    "nconf": "~0.7.1"
+    "jade": "~1.11.0",
+    "lodash": "^4.11.2",
+    "method-override": "^2.3.5",
+    "nconf": "~0.8.4",
+    "serve-favicon": "^2.3.0",
+    "serve-static": "^1.10.2"
   },
   "devDependencies": {
     "jasmine": "^2.2.1",
     "jasmine-core": "^2.2.0",
-    "karma": "^0.12.31",
-    "karma-chrome-launcher": "^0.1.8",
-    "karma-jasmine": "^0.3.5"
+    "karma": "^0.13.22",
+    "karma-chrome-launcher": "^1.0.1",
+    "karma-jasmine": "^1.0.0"
   }
 }

--- a/routes/GUI.js
+++ b/routes/GUI.js
@@ -8,7 +8,7 @@ module.exports = function (app) {
     });
 
     app.get('/data/:fileName', function (req, res) {
-        res.sendfile('/data/' + req.params.fileName, {root: './html/src/'});
+        res.sendFile('/data/' + req.params.fileName, {root: './html/src/'});
     });
 
     app.get('/partials/Index', function (req, res) {


### PR DESCRIPTION
Updated to Express 4 as per [migration guide](http://expressjs.com/en/guide/migrating-4.html).

Also, removed extraneous call to `app.configure()` as it has been officially deprecated (see: https://github.com/expressjs/express/issues/936) as well as dependency on the EJS templating engine, since it is no longer used in the project.
